### PR TITLE
Fixing problems with websites that use the Iframe at the bottom

### DIFF
--- a/src/2ClickIframePrivacy.js
+++ b/src/2ClickIframePrivacy.js
@@ -62,6 +62,8 @@
         }
         wrapper.innerHTML = '<p>' + wrapper.innerHTML + '</p>';
         wrapper.appendChild(el);
+        el.style.width = "0px"; 
+        el.style.height = "0px"
     }
 
     this.EnableContent = function (type){
@@ -107,6 +109,8 @@
         x = document.querySelectorAll('iframe[data-2click-type="'+type+'"]');
         for (i = 0; i < x.length; i++) {
             x[i].src = x[i].getAttribute("data-src");
+            x[i].style.width = x[i].getAttribute("width");
+            x[i].style.height = x[i].getAttribute("height");
         }
 
         // If available, execute the callback that is defined for the currently active type


### PR DESCRIPTION
Hi, 

I encountered an issue with the script when using the IFrame as one of the last elements in a page. 
Because the IFrame is added as a child to the created div container it still has values for width & height. Even though the element is not visible this can cause the site to require additional space at the bottom and create a scrollbar. 

here is an example that I created for testing purposes: 

![Screenshot_20200416_220339](https://user-images.githubusercontent.com/39764491/79501425-4e603400-802e-11ea-89c4-303af4f4cabb.png)
(the website does not contain anything after the IFrame)

In order to fix the issue I set the width & height of the IFrame to 0px while the element ist not visible and reset it afterwards. 

As I'm totally not an expert using javascript there might be a better way to solve the problem then the suggested one. 

Greetings, Sven